### PR TITLE
Add freeglut3 installation (required for linux mint) to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,18 @@
 # First-OpenGL-Hardcoding
 First game using OpenGL, all by hardcoding.
 
-To run just add permission to the exe file "jogo": ```sudo chmod +x jogo``` and then ```./jogo```
+## Installing
 
+You need to have the libsoil and freeglut3 lib to run
+- if you are on manjaro run: ```pamac install soil```
+- if you are on ubuntu (or based, like linux mint) run: ```sudo apt install libsoil-dev freeglut3```
+
+To run just add permission to the exe file "jogo": ```sudo chmod +x jogo``` and to open then ```./jogo```
+
+## Running game
+- On terminal, at the folder where the game is installed, run ```./jogo```
+
+## Playing
 Controls:
 - W, S, A, D for movement
 - Space bar for shooting
-
-You need to have the libsoil lib to run
-- if you are on manjaro run: ```pamac install soil```
-- if you are on ubuntu run: ```sudo apt install libsoil-dev```


### PR DESCRIPTION
For linux mint I had to install freeglut3 to get rid of error `./jogo: error while loading shared libraries: libglut.so.3: cannot open shared object file: No such file or directory`
Suggesting add this on readme installation.

Also suggesting readme organization update, see if looks good. Tell me if prefer some other way, will be glad to adjust :)